### PR TITLE
qemu script: use OVMF files with _4M suffix for 24.04 compatibility

### DIFF
--- a/uc22/boot-in-kvm.sh
+++ b/uc22/boot-in-kvm.sh
@@ -7,8 +7,8 @@ sudo qemu-system-x86_64 \
  -global ICH9-LPC.disable_s3=1 \
  -net nic,model=virtio \
  -net user,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80  \
- -drive file=/usr/share/OVMF/OVMF_CODE.secboot.fd,if=pflash,format=raw,unit=0,readonly=on \
- -drive file=/usr/share/OVMF/OVMF_VARS.ms.fd,if=pflash,format=raw,unit=1 \
+ -drive file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd,if=pflash,format=raw,unit=0,readonly=on \
+ -drive file=/usr/share/OVMF/OVMF_VARS_4M.ms.fd,if=pflash,format=raw,unit=1 \
  -drive "file=${1}",if=none,format=raw,id=disk1 \
  -device virtio-blk-pci,drive=disk1,bootindex=1 \
  -serial mon:stdio


### PR DESCRIPTION
On Noble the OVMF package does not provide the files `OVMF_CODE.secboot.fd` and `OVMF_VARS.ms.fd` (in `/usr/share/OVMF`) that the `boot-in-kvm.sh` script uses.
Only the variants with the `_4M` suffix `OVMF_CODE_4M.secboot.fd` and `OVMF_VARS_4M.ms.fd` are distributed.

The script will still work on Jammy as the `_4M` files are already present there.